### PR TITLE
GitHub Action OS 이름 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code. # 레포지토리 체크아웃
         uses: actions/checkout@master


### PR DESCRIPTION
GitHub Action 에서 Ubuntu 18.04 를 더이상 지원 하지 않아 에러가 발생하므로 OS 버전을 **Ubuntu-Latest** 로 변경 하였음.