### PR TITLE
GitHub Action 환경 변수 이름 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,8 @@ on:
       - main
 
 env:
-  PORT: 22
-  USERNAME: hackathon
+  SSH_PORT: 22
+  SSH_USERNAME: hackathon
 
 jobs:
   build:
@@ -37,8 +37,8 @@ jobs:
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.SSH_HOST }}
-          username: ${{env.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
+          username: ${{env.SSH_USERNAME }}
           port: ${{ env.SSH_PORT }}
           source: "dist/*"
           strip_components: 1


### PR DESCRIPTION
GitHub Action 환경 변수 이름에 Prefix 를 안 붙인 상태에서 에러가 발생하여 SSH_ 를 추가한 다음 업로드