### PR TITLE
GitHub Action 배포 Target 잘못된 것 수정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,4 @@ jobs:
           port: ${{ env.SSH_PORT }}
           source: "dist/*"
           strip_components: 1
-          target: "/var/www/welldying_front/dist"
+          target: "/var/www/weliving_Front/dist"


### PR DESCRIPTION
GitHub Action 배포 타겟 주소가 잘못 명시 되어 수정함.